### PR TITLE
Refactoring pt. 2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,4 +20,6 @@ cmake ..
 # Build the project
 make
 
+echo "password needed to sudo make install"
+
 sudo make install

--- a/include/GolfBallFlight.hpp
+++ b/include/GolfBallFlight.hpp
@@ -87,7 +87,6 @@ private:
 	void calculatePosition();
 	void calculateV();
 	void calculateVelocityw();
-	void calculateVw();
 
 	void calculatePhi();
 	void calculateTau();

--- a/src/GolfBallPhysicsVariables.cpp
+++ b/src/GolfBallPhysicsVariables.cpp
@@ -21,6 +21,18 @@
 #include <cmath>
 #include <iostream>
 
+/**
+ * @brief Constructs a GolfBallPhysicsVariables object.
+ *
+ * This constructor initializes a GolfBallPhysicsVariables object with the given golf ball and atmospheric data.
+ *
+ * @param ball The golf ball structure containing relevant data.
+ * @param atmos The atmospheric data structure containing relevant data.
+ *
+ * @note The user is responsible for validating the ball and atmos structures before passing them to this constructor.
+ *       This class assumes that the input data is valid and within physically reasonable ranges.
+ *       Passing invalid or out-of-range data may lead to unexpected behavior or incorrect calculations.
+ */
 GolfBallPhysicsVariables::GolfBallPhysicsVariables(const struct golfBall &ball, const struct atmosphericData &atmos)
     : ball(ball), atmos(atmos), beta(0.0001217f)
 {

--- a/src/Simulator.cpp
+++ b/src/Simulator.cpp
@@ -90,9 +90,9 @@ void Simulator::calculateNextStep()
 /**
  * Checks if the flight is over.
  *
- * @return true if the ball position.z < 0, false otherwise.
+ * @return true if the ball position.z < 0.0, false otherwise.
  */
 bool Simulator::isFlightOver() const
 {
-    return flight.getPosition()[2] < 0;
+    return flight.getPosition()[2] < 0.0;
 }

--- a/src/math_utils.cpp
+++ b/src/math_utils.cpp
@@ -70,7 +70,7 @@ float math_utils::convertMetersToFeet(float meters)
 }
 
 /**
- * Calculates the distance in yards from the origin to the given position.
+ * Calculates the distance in yards from the origin to the given landing position.
  *
  * @param position The position in 3D space.
  * @return The distance in yards.


### PR DESCRIPTION
- remove duplicate function
- directly access class variables when possible (not use 'getter' in the same class)
- add documentation to constructors
    - clarify that the user is responsible for verifying the ball/atmosphere struct values, not libshotscope
- fix comparison in `Simulator::isFlightOver()`
    - now correctly uses the float 0.0 value